### PR TITLE
주식 매수, 매도 기능 구현 PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	//DB
+	implementation 'mysql:mysql-connector-java:8.0.33'
+	runtimeOnly 'com.h2database:h2'
 
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/example/stocksimulation/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/stocksimulation/configuration/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .sessionManagement(manager -> manager.sessionCreationPolicy(STATELESS))
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .requestMatchers("/sign-in", "/sign-up", "/client/stocks").permitAll()
+                        .requestMatchers("/sign-in", "/sign-up", "/stocks-infos").permitAll()
                         .anyRequest().hasRole("USER")
                 )
                 .addFilterBefore(new JwtAuthFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class).build();

--- a/src/main/java/com/example/stocksimulation/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/stocksimulation/configuration/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .sessionManagement(manager -> manager.sessionCreationPolicy(STATELESS))
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
-                        .requestMatchers("/sign-in", "/sign-up").permitAll()
+                        .requestMatchers("/sign-in", "/sign-up", "/client/stocks").permitAll()
                         .anyRequest().hasRole("USER")
                 )
                 .addFilterBefore(new JwtAuthFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class).build();

--- a/src/main/java/com/example/stocksimulation/configuration/WebSocketConfig.java
+++ b/src/main/java/com/example/stocksimulation/configuration/WebSocketConfig.java
@@ -20,6 +20,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/client/stocks").setAllowedOrigins("*");
+        registry.addHandler(webSocketHandler, "/stocks-infos").setAllowedOrigins("*");
     }
 }

--- a/src/main/java/com/example/stocksimulation/configuration/WebSocketConfig.java
+++ b/src/main/java/com/example/stocksimulation/configuration/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.example.stocksimulation.configuration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+    private final WebSocketHandler webSocketHandler;
+
+    @Autowired
+    public WebSocketConfig(@Qualifier("clientToServerHandler") WebSocketHandler webSocketHandler) {
+        this.webSocketHandler = webSocketHandler;
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/client/stocks").setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -3,6 +3,7 @@ package com.example.stocksimulation.domain.entity;
 import jakarta.persistence.*;
 
 import java.util.List;
+import java.util.Map;
 
 @Entity
 public class Account {
@@ -12,5 +13,5 @@ public class Account {
 
     private long money;
     @OneToMany
-    private List<Stock> stocks;
+    private Map<Stock, Integer> stocks;
 }

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -1,7 +1,7 @@
 package com.example.stocksimulation.domain.entity;
 
 import com.example.stocksimulation.domain.vo.TradeType;
-import com.example.stocksimulation.domain.vo.TradeVO;
+import com.example.stocksimulation.domain.vo.ZeroTradeQuantity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -62,7 +61,7 @@ public class Account {
         }
 
         for (Trade trade : sells) {
-            if (quantity <= TradeVO.EMPTY_TRADE.getQuantity()) {
+            if (quantity <= ZeroTradeQuantity.EMPTY_TRADE.getQuantity()) {
                 break;
             }
 
@@ -71,7 +70,7 @@ public class Account {
             if (tradeQuantity >= quantity) {
                 trade.sell(quantity);
                 this.money += quantity * sellTrade.getStock().getPrice();
-                quantity = TradeVO.EMPTY_TRADE.getQuantity();
+                quantity = ZeroTradeQuantity.EMPTY_TRADE.getQuantity();
             } else {
                 this.money += tradeQuantity * sellTrade.getStock().getPrice();
                 quantity -= tradeQuantity;

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -1,10 +1,12 @@
 package com.example.stocksimulation.domain.entity;
 
+import com.example.stocksimulation.domain.vo.TradeType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -18,14 +20,47 @@ public class Account {
 
     private long money;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
+    @OneToOne(mappedBy = "account")
     private Member member;
 
     @OneToMany(mappedBy = "account")
     private List<Trade> trades;
 
-    public void buy(long price) {
-        this.money -= price;
+    public void buy(Trade trade) {
+        long priceToPayment = trade.getQuantity() * trade.getStock().getPrice();
+
+        if (this.money >= priceToPayment) {
+            this.money -= priceToPayment;
+            this.trades.add(trade);
+        } else {
+            throw new IllegalArgumentException("not enough money");
+        }
+    }
+
+    public void sell(Trade sellTrade) {
+        List<Trade> sells = trades.stream()
+                .filter(trade -> trade.getStock().getCode().equals(sellTrade.getStock().getCode()) &&
+                        trade.getTradeType().equals(TradeType.BUY))
+                .sorted(Comparator.comparingInt(Trade::getQuantity).reversed())
+                .toList();
+
+        int quantity = sellTrade.getQuantity();
+
+        for (Trade trade : sells) {
+            if (quantity <= 0) {
+                break;
+            }
+
+            int tradeQuantity = trade.getQuantity();
+
+            if (tradeQuantity >= quantity) {
+                trade.sell(quantity);
+                this.money += quantity * sellTrade.getStock().getPrice();
+                quantity = 0;
+            } else {
+                this.money += tradeQuantity * sellTrade.getStock().getPrice();
+                quantity -= tradeQuantity;
+            }
+        }
     }
 }

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -21,7 +21,7 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
-    private long money = 500000;
+    private long money = 0;
 
     @OneToOne(mappedBy = "account")
     private Member member;

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -4,9 +4,11 @@ import com.example.stocksimulation.domain.vo.TradeType;
 import com.example.stocksimulation.domain.vo.TradeVO;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -19,16 +21,21 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
-    private long money;
+    private long money = 500000;
 
     @OneToOne(mappedBy = "account")
     private Member member;
 
     @OneToMany(mappedBy = "account")
-    private List<Trade> trades;
+    private List<Trade> trades = new ArrayList<>();
 
     @OneToMany(mappedBy = "account")
-    private List<TradeTrace> traces;
+    private List<TradeTrace> traces = new ArrayList<>();
+
+    @Builder
+    public Account(Member member) {
+        this.member = member;
+    }
 
     public void buy(Trade trade) {
         long priceToPayment = trade.getQuantity() * trade.getStock().getPrice();

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -22,7 +22,6 @@ public class Account {
     private long id;
 
     private long money = 500000;
-    private long balance;
 
     @OneToOne(mappedBy = "account")
     private Member member;
@@ -78,5 +77,15 @@ public class Account {
                 quantity -= tradeQuantity;
             }
         }
+    }
+
+    public long calculateBalance() {
+        long balance = 0;
+
+        for (Trade trade : trades) {
+            balance += trade.getQuantity() * trade.getStock().getPrice();
+        }
+
+        return balance;
     }
 }

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -27,6 +27,9 @@ public class Account {
     @OneToMany(mappedBy = "account")
     private List<Trade> trades;
 
+    @OneToMany(mappedBy = "account")
+    private List<TradeTrace> traces;
+
     public void buy(Trade trade) {
         long priceToPayment = trade.getQuantity() * trade.getStock().getPrice();
 

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -1,6 +1,7 @@
 package com.example.stocksimulation.domain.entity;
 
 import com.example.stocksimulation.domain.vo.TradeType;
+import com.example.stocksimulation.domain.vo.TradeVO;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -47,7 +48,7 @@ public class Account {
         int quantity = sellTrade.getQuantity();
 
         for (Trade trade : sells) {
-            if (quantity <= 0) {
+            if (quantity <= TradeVO.EMPTY_TRADE.getQuantity()) {
                 break;
             }
 
@@ -56,7 +57,7 @@ public class Account {
             if (tradeQuantity >= quantity) {
                 trade.sell(quantity);
                 this.money += quantity * sellTrade.getStock().getPrice();
-                quantity = 0;
+                quantity = TradeVO.EMPTY_TRADE.getQuantity();
             } else {
                 this.money += tradeQuantity * sellTrade.getStock().getPrice();
                 quantity -= tradeQuantity;

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -22,6 +22,7 @@ public class Account {
     private long id;
 
     private long money = 500000;
+    private long balance;
 
     @OneToOne(mappedBy = "account")
     private Member member;
@@ -56,6 +57,10 @@ public class Account {
                 .toList();
 
         int quantity = sellTrade.getQuantity();
+
+        if (quantity > sells.get(0).getQuantity()) {
+            throw new IllegalArgumentException("you don't have enough stocks");
+        }
 
         for (Trade trade : sells) {
             if (quantity <= TradeVO.EMPTY_TRADE.getQuantity()) {

--- a/src/main/java/com/example/stocksimulation/domain/entity/Account.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Account.java
@@ -1,10 +1,15 @@
 package com.example.stocksimulation.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Entity
 public class Account {
     @Id
@@ -12,6 +17,15 @@ public class Account {
     private long id;
 
     private long money;
-    @OneToMany
-    private Map<Stock, Integer> stocks;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "account")
+    private List<Trade> trades;
+
+    public void buy(long price) {
+        this.money -= price;
+    }
 }

--- a/src/main/java/com/example/stocksimulation/domain/entity/Member.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Member.java
@@ -29,8 +29,9 @@ public class Member implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
-    private List<Account> accounts = new ArrayList<>();
+    @OneToOne
+    @JoinColumn(name = "account_id")
+    private Account account;
 
     @Builder
     public Member(String name, String email, String password, List<String> roles) {

--- a/src/main/java/com/example/stocksimulation/domain/entity/Member.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Member.java
@@ -29,7 +29,7 @@ public class Member implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles = new ArrayList<>();
 
-    @OneToMany
+    @OneToMany(mappedBy = "member")
     private List<Account> accounts = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/example/stocksimulation/domain/entity/Member.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Member.java
@@ -51,6 +51,10 @@ public class Member implements UserDetails {
         }
     }
 
+    public void setAccount(Account account) {
+        this.account = account;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return  this.roles.stream()

--- a/src/main/java/com/example/stocksimulation/domain/entity/Stock.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Stock.java
@@ -21,10 +21,6 @@ public class Stock {
         this.price = price;
     }
 
-    public StockDto toDto() {
-        return new StockDto(code, price, name);
-    }
-
     @Builder
     public Stock(String code, int price, String name) {
         this.code= code;

--- a/src/main/java/com/example/stocksimulation/domain/entity/Stock.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Stock.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class Stock {
     @Id
     private String code;
-    private int price;
+    private long price;
     private String name;
 
     public void updatePrice(int price) {

--- a/src/main/java/com/example/stocksimulation/domain/entity/Stock.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Stock.java
@@ -1,8 +1,15 @@
 package com.example.stocksimulation.domain.entity;
 
+import com.example.stocksimulation.dto.stock.StockDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Entity
 public class Stock {
     @Id
@@ -12,5 +19,16 @@ public class Stock {
 
     public void updatePrice(int price) {
         this.price = price;
+    }
+
+    public StockDto toDto() {
+        return new StockDto(code, price, name);
+    }
+
+    @Builder
+    public Stock(String code, int price, String name) {
+        this.code= code;
+        this.price = price;
+        this.name = name;
     }
 }

--- a/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
@@ -36,6 +36,10 @@ public class Trade {
         this.tradeType = tradeType;
     }
 
+    public void buy(int quantity) {
+        this.quantity += quantity;
+    }
+
     public void sell(int quantity) {
         this.quantity -= quantity;
     }

--- a/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
@@ -1,0 +1,37 @@
+package com.example.stocksimulation.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Trade {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @ManyToOne
+    @JoinColumn(name = "stock_id")
+    private Stock stock;
+
+    private int quantity;
+
+    @Builder
+    public Trade(Account account, Stock stock, int quantity) {
+        this.account = account;
+        this.stock = stock;
+        this.quantity = quantity;
+    }
+
+    public void sell(int quantity) {
+        this.quantity -= quantity;
+    }
+}

--- a/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
@@ -39,4 +39,16 @@ public class Trade {
     public void sell(int quantity) {
         this.quantity -= quantity;
     }
+
+    public String getStockCode() {
+        return stock.getCode();
+    }
+
+    public String getStockName() {
+        return stock.getName();
+    }
+
+    public long getStockPrice() {
+        return stock.getPrice();
+    }
 }

--- a/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/Trade.java
@@ -1,5 +1,6 @@
 package com.example.stocksimulation.domain.entity;
 
+import com.example.stocksimulation.domain.vo.TradeType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,11 +25,15 @@ public class Trade {
 
     private int quantity;
 
+    @Enumerated(EnumType.STRING)
+    private TradeType tradeType;
+
     @Builder
-    public Trade(Account account, Stock stock, int quantity) {
+    public Trade(Account account, Stock stock, int quantity, TradeType tradeType) {
         this.account = account;
         this.stock = stock;
         this.quantity = quantity;
+        this.tradeType = tradeType;
     }
 
     public void sell(int quantity) {

--- a/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
@@ -41,8 +41,4 @@ public class TradeTrace {
         this.quantity = trade.getQuantity();
         this.tradeType = trade.getTradeType();
     }
-
-    public TradeTraceDto toDto() {
-        return new TradeTraceDto(date, stockName, stockCode, price, quantity);
-    }
 }

--- a/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
@@ -1,0 +1,43 @@
+package com.example.stocksimulation.domain.entity;
+
+import com.example.stocksimulation.domain.vo.TradeType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class TradeTrace {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    private LocalDateTime date;
+    private String stockCode;
+    private String stockName;
+    private long price;
+    private int quantity;
+
+    @Enumerated(EnumType.STRING)
+    private TradeType tradeType;
+
+    @Builder
+    public TradeTrace(Trade trade) {
+        this.date = LocalDateTime.now();
+        this.account = trade.getAccount();
+        this.stockCode = trade.getStock().getCode();
+        this.stockName = trade.getStock().getName();
+        this.price = trade.getStock().getPrice();
+        this.quantity = trade.getQuantity();
+        this.tradeType = trade.getTradeType();
+    }
+}

--- a/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
@@ -35,9 +35,9 @@ public class TradeTrace {
     public TradeTrace(Trade trade) {
         this.date = LocalDateTime.now();
         this.account = trade.getAccount();
-        this.stockCode = trade.getStock().getCode();
-        this.stockName = trade.getStock().getName();
-        this.price = trade.getStock().getPrice();
+        this.stockCode = trade.getStockCode();
+        this.stockName = trade.getStockName();
+        this.price = trade.getStockPrice();
         this.quantity = trade.getQuantity();
         this.tradeType = trade.getTradeType();
     }

--- a/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
+++ b/src/main/java/com/example/stocksimulation/domain/entity/TradeTrace.java
@@ -1,6 +1,7 @@
 package com.example.stocksimulation.domain.entity;
 
 import com.example.stocksimulation.domain.vo.TradeType;
+import com.example.stocksimulation.dto.trade.TradeTraceDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -39,5 +40,9 @@ public class TradeTrace {
         this.price = trade.getStock().getPrice();
         this.quantity = trade.getQuantity();
         this.tradeType = trade.getTradeType();
+    }
+
+    public TradeTraceDto toDto() {
+        return new TradeTraceDto(date, stockName, stockCode, price, quantity);
     }
 }

--- a/src/main/java/com/example/stocksimulation/domain/vo/TradeType.java
+++ b/src/main/java/com/example/stocksimulation/domain/vo/TradeType.java
@@ -1,0 +1,11 @@
+package com.example.stocksimulation.domain.vo;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TradeType {
+    BUY("B"),
+    SELL("S");
+
+    private final String type;
+}

--- a/src/main/java/com/example/stocksimulation/domain/vo/TradeVO.java
+++ b/src/main/java/com/example/stocksimulation/domain/vo/TradeVO.java
@@ -1,0 +1,12 @@
+package com.example.stocksimulation.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TradeVO {
+    EMPTY_TRADE(0);
+
+    private final int quantity;
+}

--- a/src/main/java/com/example/stocksimulation/domain/vo/WebSocketConnectInfo.java
+++ b/src/main/java/com/example/stocksimulation/domain/vo/WebSocketConnectInfo.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class WebSocketConnectedVO {
+public class WebSocketConnectInfo {
     String msg1;
     String iv;
     String key;

--- a/src/main/java/com/example/stocksimulation/domain/vo/WebSocketIndexNumber.java
+++ b/src/main/java/com/example/stocksimulation/domain/vo/WebSocketIndexNumber.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum TradeVO {
-    EMPTY_TRADE(0);
+public enum WebSocketIndexNumber {
+    INDEX_OF_RESPONSE(3),
+    INDEX_OF_CODE(0),
+    INDEX_OF_PRICE(2);
 
-    private final int quantity;
+    private final int value;
 }

--- a/src/main/java/com/example/stocksimulation/domain/vo/WebSocketParsingInfo.java
+++ b/src/main/java/com/example/stocksimulation/domain/vo/WebSocketParsingInfo.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum WebSocketClientVO {
+public enum WebSocketParsingInfo {
     WEB_SOCKET_CLIENT_RESPONSE("\"유가증권단축종목코드|주식체결시간|주식현재가|전일대비부호|전일대비|전일대비율|가중평균주식가격|주식시가|주식최고가|주식최저가|매도호가1|매수호가1|체결거래량|누적거래량|누적거래대금|매도체결건수|매수체결건수|순매수체결건수|체결강도|총매도수량|총매수수량|체결구분|매수비율|전일거래량대비등락율|시가시간|시가대비구분|시가대비|최고가시간|고가대비구분|고가대비|최저가시간|저가대비구분|저가대비|영업일자|신장운영구분코드|거래정지여부|매도호가잔량|매수호가잔량|총매도호가잔량|총매수호가잔량|거래량회전율|전일동시간누적거래량|전일동시간누적거래량비율|시간구분코드|임의종료구분코드|정적VI발동기준가\""),
     WEB_SOCKET_CLIENT_REQUEST("{\"header\":{\"approval_key\":\"1d2d8d5f-b6de-46e5-be74-96312a693a76\",\"custtype\":\"P\",\"tr_type\":\"1\",\"content-type\":\"utf-8\"},\"body\":{\"input\":{\"tr_id\":\"H0STCNT0\",\"tr_key\":\"005930\"}}}"),
     WEB_SOCKET_CLIENT_URL("ws://ops.koreainvestment.com:21000/tryitout/H0STCNT0"),

--- a/src/main/java/com/example/stocksimulation/domain/vo/ZeroTradeQuantity.java
+++ b/src/main/java/com/example/stocksimulation/domain/vo/ZeroTradeQuantity.java
@@ -5,10 +5,8 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum WebSocketClientNumberVO {
-    INDEX_OF_RESPONSE(3),
-    INDEX_OF_CODE(0),
-    INDEX_OF_PRICE(2);
+public enum ZeroTradeQuantity {
+    EMPTY_TRADE(0);
 
-    private final int value;
+    private final int quantity;
 }

--- a/src/main/java/com/example/stocksimulation/dto/account/AccountInfoDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/account/AccountInfoDto.java
@@ -1,0 +1,12 @@
+package com.example.stocksimulation.dto.account;
+
+import com.example.stocksimulation.dto.trade.TradeResponseDto;
+
+import java.util.List;
+
+public record AccountInfoDto(
+        String memberName,
+        long money,
+        List<TradeResponseDto> trades
+) {
+}

--- a/src/main/java/com/example/stocksimulation/dto/account/BalanceDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/account/BalanceDto.java
@@ -1,0 +1,6 @@
+package com.example.stocksimulation.dto.account;
+
+public record BalanceDto(
+        long balance
+) {
+}

--- a/src/main/java/com/example/stocksimulation/dto/membership/MemberUpdateDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/membership/MemberUpdateDto.java
@@ -1,7 +1,6 @@
 package com.example.stocksimulation.dto.membership;
 
 public record MemberUpdateDto(
-        long memberId,
         String nickName,
         String password
 ) {

--- a/src/main/java/com/example/stocksimulation/dto/stock/StockDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/stock/StockDto.java
@@ -2,7 +2,7 @@ package com.example.stocksimulation.dto.stock;
 
 public record StockDto(
         String code,
-        int price,
+        long price,
         String name
 ) {
 }

--- a/src/main/java/com/example/stocksimulation/dto/stock/StockDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/stock/StockDto.java
@@ -1,0 +1,8 @@
+package com.example.stocksimulation.dto.stock;
+
+public record StockDto(
+        String code,
+        int price,
+        String name
+) {
+}

--- a/src/main/java/com/example/stocksimulation/dto/trade/TradeRequestDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/trade/TradeRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.stocksimulation.dto.trade;
+
+public record TradeRequestDto(
+        long accountId,
+        String stockCode,
+        int quantity
+) {
+}

--- a/src/main/java/com/example/stocksimulation/dto/trade/TradeRequestDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/trade/TradeRequestDto.java
@@ -1,7 +1,6 @@
 package com.example.stocksimulation.dto.trade;
 
 public record TradeRequestDto(
-        long accountId,
         String stockCode,
         int quantity
 ) {

--- a/src/main/java/com/example/stocksimulation/dto/trade/TradeResponseDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/trade/TradeResponseDto.java
@@ -1,0 +1,6 @@
+package com.example.stocksimulation.dto.trade;
+
+public record TradeResponseDto(
+
+) {
+}

--- a/src/main/java/com/example/stocksimulation/dto/trade/TradeResponseDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/trade/TradeResponseDto.java
@@ -7,6 +7,6 @@ public record TradeResponseDto(
         int quantity
 ) {
     public static TradeResponseDto fromTrade(Trade trade) {
-        return new TradeResponseDto(trade.getStock().getName(), trade.getQuantity());
+        return new TradeResponseDto(trade.getStockName(), trade.getQuantity());
     }
 }

--- a/src/main/java/com/example/stocksimulation/dto/trade/TradeResponseDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/trade/TradeResponseDto.java
@@ -1,6 +1,12 @@
 package com.example.stocksimulation.dto.trade;
 
-public record TradeResponseDto(
+import com.example.stocksimulation.domain.entity.Trade;
 
+public record TradeResponseDto(
+        String stockName,
+        int quantity
 ) {
+    public static TradeResponseDto fromTrade(Trade trade) {
+        return new TradeResponseDto(trade.getStock().getName(), trade.getQuantity());
+    }
 }

--- a/src/main/java/com/example/stocksimulation/dto/trade/TradeTraceDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/trade/TradeTraceDto.java
@@ -1,0 +1,12 @@
+package com.example.stocksimulation.dto.trade;
+
+import java.time.LocalDateTime;
+
+public record TradeTraceDto(
+        LocalDateTime dateTime,
+        String stockName,
+        String stockCode,
+        long price,
+        int quantity
+) {
+}

--- a/src/main/java/com/example/stocksimulation/dto/trade/TradeTraceDto.java
+++ b/src/main/java/com/example/stocksimulation/dto/trade/TradeTraceDto.java
@@ -1,5 +1,7 @@
 package com.example.stocksimulation.dto.trade;
 
+import com.example.stocksimulation.domain.entity.TradeTrace;
+
 import java.time.LocalDateTime;
 
 public record TradeTraceDto(
@@ -9,4 +11,11 @@ public record TradeTraceDto(
         long price,
         int quantity
 ) {
+    public static TradeTraceDto create(TradeTrace trace) {
+        return new TradeTraceDto(trace.getDate(),
+        trace.getStockName(),
+        trace.getStockCode(),
+        trace.getPrice(),
+        trace.getQuantity());
+    }
 }

--- a/src/main/java/com/example/stocksimulation/repository/AccountRepository.java
+++ b/src/main/java/com/example/stocksimulation/repository/AccountRepository.java
@@ -1,0 +1,7 @@
+package com.example.stocksimulation.repository;
+
+import com.example.stocksimulation.domain.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/com/example/stocksimulation/repository/MemberRepository.java
+++ b/src/main/java/com/example/stocksimulation/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Member getMemberByEmail(String email);
 }

--- a/src/main/java/com/example/stocksimulation/repository/TradeRepository.java
+++ b/src/main/java/com/example/stocksimulation/repository/TradeRepository.java
@@ -1,0 +1,7 @@
+package com.example.stocksimulation.repository;
+
+import com.example.stocksimulation.domain.entity.Trade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+}

--- a/src/main/java/com/example/stocksimulation/repository/TradeRepository.java
+++ b/src/main/java/com/example/stocksimulation/repository/TradeRepository.java
@@ -3,5 +3,8 @@ package com.example.stocksimulation.repository;
 import com.example.stocksimulation.domain.entity.Trade;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TradeRepository extends JpaRepository<Trade, Long> {
+    List<Trade> findAllByQuantity(int quantity);
 }

--- a/src/main/java/com/example/stocksimulation/repository/TradeRepository.java
+++ b/src/main/java/com/example/stocksimulation/repository/TradeRepository.java
@@ -1,5 +1,6 @@
 package com.example.stocksimulation.repository;
 
+import com.example.stocksimulation.domain.entity.Account;
 import com.example.stocksimulation.domain.entity.Trade;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,5 @@ import java.util.List;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
     List<Trade> findAllByQuantity(int quantity);
+    List<Trade> findAllByAccount(Account account);
 }

--- a/src/main/java/com/example/stocksimulation/repository/TradeTraceRepository.java
+++ b/src/main/java/com/example/stocksimulation/repository/TradeTraceRepository.java
@@ -1,0 +1,7 @@
+package com.example.stocksimulation.repository;
+
+import com.example.stocksimulation.domain.entity.TradeTrace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeTraceRepository extends JpaRepository<TradeTrace, Long> {
+}

--- a/src/main/java/com/example/stocksimulation/service/account/AccountService.java
+++ b/src/main/java/com/example/stocksimulation/service/account/AccountService.java
@@ -1,4 +1,45 @@
 package com.example.stocksimulation.service.account;
 
+import com.example.stocksimulation.domain.entity.Account;
+import com.example.stocksimulation.domain.entity.Member;
+import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.dto.account.AccountInfoDto;
+import com.example.stocksimulation.dto.trade.TradeResponseDto;
+import com.example.stocksimulation.repository.AccountRepository;
+import com.example.stocksimulation.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@Service
 public class AccountService {
+    private final AccountRepository accountRepository;
+    private final MemberRepository memberRepository;
+
+    public AccountInfoDto create(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NoSuchElementException::new);
+
+        Account account = new Account(member);
+        accountRepository.save(account);
+        return new AccountInfoDto(member.getNickName(), 0, null);
+    }
+
+    public AccountInfoDto readAccount(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NoSuchElementException::new);
+
+        Account account = member.getAccount();
+        List<TradeResponseDto> trades = new ArrayList<>();
+
+        for (Trade trade : account.getTrades()) {
+            trades.add(TradeResponseDto.fromTrade(trade));
+        }
+
+        return new AccountInfoDto(member.getNickName(), account.getMoney(), trades);
+    }
 }

--- a/src/main/java/com/example/stocksimulation/service/account/AccountService.java
+++ b/src/main/java/com/example/stocksimulation/service/account/AccountService.java
@@ -1,0 +1,4 @@
+package com.example.stocksimulation.service.account;
+
+public class AccountService {
+}

--- a/src/main/java/com/example/stocksimulation/service/account/AccountService.java
+++ b/src/main/java/com/example/stocksimulation/service/account/AccountService.java
@@ -42,4 +42,12 @@ public class AccountService {
 
         return new AccountInfoDto(member.getNickName(), account.getMoney(), trades);
     }
+
+    public long getBalance(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(NoSuchElementException::new);
+
+        Account account = member.getAccount();
+        return account.calculateBalance();
+    }
 }

--- a/src/main/java/com/example/stocksimulation/service/membership/MemberService.java
+++ b/src/main/java/com/example/stocksimulation/service/membership/MemberService.java
@@ -50,19 +50,19 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberUpdateDto update(MemberUpdateDto updateDto) {
-        Member member = repository.findById(updateDto.memberId())
+    public MemberUpdateDto update(MemberUpdateDto updateDto, String email) {
+        Member member = repository.findByEmail(email)
                 .orElseThrow(NoSuchElementException::new);
 
         member.update(updateDto.nickName(), updateDto.password());
         return updateDto;
     }
 
-    public Long delete(long memberId) {
-        Member target = repository.findById(memberId)
+    public String delete(String email) {
+        Member target = repository.findByEmail(email)
                 .orElseThrow(NoSuchElementException::new);
 
         repository.delete(target);
-        return memberId;
+        return email;
     }
 }

--- a/src/main/java/com/example/stocksimulation/service/stock/BuyTrader.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/BuyTrader.java
@@ -1,0 +1,28 @@
+package com.example.stocksimulation.service.stock;
+
+import com.example.stocksimulation.domain.entity.Account;
+import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.repository.TradeRepository;
+
+public class BuyTrader extends Trader {
+    public BuyTrader(TradeRepository tradeRepository) {
+        super(tradeRepository);
+    }
+
+    @Override
+    public void trade(Account account, Trade trade) {
+        if (account.hasTrade(trade.getStockCode())) {
+            account.buy(trade.getQuantity(), trade.getStockPrice());
+            tradeRepository.findAllByAccount(account).stream()
+                    .filter(oldTrade -> oldTrade.getStockCode().equals(trade.getStockCode()))
+                    .findFirst()
+                    .get()
+                    .buy(trade.getQuantity());
+        } else {
+            account.buy(trade.getQuantity(), trade.getStockPrice());
+            tradeRepository.save(trade);
+            account.getTrades().add(trade);
+        }
+
+    }
+}

--- a/src/main/java/com/example/stocksimulation/service/stock/SellTrader.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/SellTrader.java
@@ -1,0 +1,19 @@
+package com.example.stocksimulation.service.stock;
+
+import com.example.stocksimulation.domain.entity.Account;
+import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.repository.TradeRepository;
+
+public class SellTrader extends Trader {
+    public SellTrader(TradeRepository tradeRepository) {
+        super(tradeRepository);
+    }
+
+    @Override
+    public void trade(Account account, Trade trade) {
+        if (account.canSell(trade.getStockCode(), trade.getQuantity())) {
+            account.sell(trade.getQuantity(), trade.getStockPrice());
+            trade.sell(trade.getQuantity());
+        }
+    }
+}

--- a/src/main/java/com/example/stocksimulation/service/stock/StockService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/StockService.java
@@ -1,7 +1,9 @@
 package com.example.stocksimulation.service.stock;
 
 import com.example.stocksimulation.domain.entity.Stock;
+import com.example.stocksimulation.dto.stock.StockDto;
 import com.example.stocksimulation.repository.StockRepository;
+import com.example.stocksimulation.service.support.WebSocketClientToServerHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,11 +13,26 @@ import java.util.NoSuchElementException;
 @Service
 public class StockService {
     private final StockRepository repository;
+    private final WebSocketClientToServerHandler socketServerHandler;
 
-    public void updateStockPrice(String stockCode, String price) {
+    public void updateStockPrice(String stockCode, int price) {
         Stock stock = repository.findByCode(stockCode)
                 .orElseThrow(NoSuchElementException::new);
+        if (stock.getPrice() != price) {
+            stock.updatePrice(price);
+            StockDto stockDto = stock.toDto();
+            socketServerHandler.stocks.put(stockCode, stockDto);
+            socketServerHandler.sendStockDtoToAllClients(stockDto);
+        }
+    }
 
-        stock.updatePrice(Integer.parseInt(price));
+    public void saveTest() {
+        Stock stock = Stock.builder()
+                .code("005930")
+                .name("test")
+                .price(10000)
+                .build();
+
+        repository.save(stock);
     }
 }

--- a/src/main/java/com/example/stocksimulation/service/stock/StockService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/StockService.java
@@ -20,7 +20,7 @@ public class StockService {
                 .orElseThrow(NoSuchElementException::new);
         if (stock.getPrice() != price) {
             stock.updatePrice(price);
-            StockDto stockDto = stock.toDto();
+            StockDto stockDto = new StockDto(stockCode, price, stock.getName());
             socketServerHandler.stocks.put(stockCode, stockDto);
             socketServerHandler.sendStockDtoToAllClients(stockDto);
         }

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
@@ -4,8 +4,8 @@ import com.example.stocksimulation.domain.entity.Account;
 import com.example.stocksimulation.domain.entity.Member;
 import com.example.stocksimulation.domain.entity.Stock;
 import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.domain.vo.TradeType;
 import com.example.stocksimulation.dto.trade.TradeRequestDto;
-import com.example.stocksimulation.repository.AccountRepository;
 import com.example.stocksimulation.repository.MemberRepository;
 import com.example.stocksimulation.repository.StockRepository;
 import com.example.stocksimulation.repository.TradeRepository;
@@ -13,9 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.security.sasl.AuthenticationException;
-import java.util.Comparator;
-import java.util.List;
 import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
@@ -23,69 +20,41 @@ import java.util.NoSuchElementException;
 public class TradeService {
     private final TradeRepository tradeRepository;
     private final MemberRepository memberRepository;
-    private final AccountRepository accountRepository;
     private final StockRepository stockRepository;
 
     @Transactional
-    public boolean buy(String memberEmail, TradeRequestDto dto) throws AuthenticationException {
+    public boolean trade(String memberEmail, TradeRequestDto dto, TradeType tradeType) {
         Member member = memberRepository.getMemberByEmail(memberEmail);
-        Account account = accountRepository.findById(dto.accountId())
+        Stock stock = stockRepository.findByCode(dto.stockCode())
                 .orElseThrow(NoSuchElementException::new);
+        Account account = member.getAccount();
 
-        if (member.getAccounts().contains(account)) {
-            Stock stock = stockRepository.findByCode(dto.stockCode())
-                    .orElseThrow(NoSuchElementException::new);
-            long needMoney = stock.getPrice() * dto.quantity();
+        Trade trade;
+        switch (tradeType) {
+            case BUY :
+                trade = Trade.builder()
+                    .account(account)
+                    .stock(stock)
+                    .quantity(dto.quantity())
+                    .tradeType(TradeType.BUY)
+                    .build();
 
-            if (account.getMoney() >= needMoney) {
-                Trade trade = Trade.builder()
+                account.buy(trade);
+                tradeRepository.save(trade);
+                break;
+            case SELL :
+                trade = Trade.builder()
                         .account(account)
                         .stock(stock)
                         .quantity(dto.quantity())
+                        .tradeType(TradeType.BUY)
                         .build();
 
-                account.buy(needMoney);
-                account.getTrades().add(trade);
+                account.sell(trade);
                 tradeRepository.save(trade);
-                return true;
-            } else {
-                throw new IllegalArgumentException("not enough money");
-            }
-        } else {
-            throw new AuthenticationException();
+                break;
         }
-    }
 
-    public boolean sell(String memberEmail, TradeRequestDto dto) throws AuthenticationException {
-        Member member = memberRepository.getMemberByEmail(memberEmail);
-        Account account = accountRepository.findById(dto.accountId())
-                .orElseThrow(NoSuchElementException::new);
-
-        if (member.getAccounts().contains(account)) {
-            List<Trade> trades = account.getTrades().stream()
-                    .filter(trade -> trade.getStock().getCode().equals(dto.stockCode()))
-                    .sorted(Comparator.comparingInt(Trade::getQuantity).reversed())
-                    .toList();
-
-            int remainingQuantity = dto.quantity();
-
-            for (Trade trade : trades) {
-                if (remainingQuantity <= 0) {
-                    break;
-                }
-
-                int tradeQuantity = trade.getQuantity();
-                if (tradeQuantity >= remainingQuantity) {
-                    trade.sell(remainingQuantity);
-                    remainingQuantity = 0;
-                } else {
-                    tradeRepository.delete(trade);
-                    remainingQuantity -= tradeQuantity;
-                }
-            }
-            return true;
-        } else {
-            throw new AuthenticationException();
-        }
+        return true;
     }
 }

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
@@ -1,0 +1,91 @@
+package com.example.stocksimulation.service.stock;
+
+import com.example.stocksimulation.domain.entity.Account;
+import com.example.stocksimulation.domain.entity.Member;
+import com.example.stocksimulation.domain.entity.Stock;
+import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.dto.trade.TradeRequestDto;
+import com.example.stocksimulation.repository.AccountRepository;
+import com.example.stocksimulation.repository.MemberRepository;
+import com.example.stocksimulation.repository.StockRepository;
+import com.example.stocksimulation.repository.TradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.security.sasl.AuthenticationException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@Service
+public class TradeService {
+    private final TradeRepository tradeRepository;
+    private final MemberRepository memberRepository;
+    private final AccountRepository accountRepository;
+    private final StockRepository stockRepository;
+
+    @Transactional
+    public boolean buy(String memberEmail, TradeRequestDto dto) throws AuthenticationException {
+        Member member = memberRepository.getMemberByEmail(memberEmail);
+        Account account = accountRepository.findById(dto.accountId())
+                .orElseThrow(NoSuchElementException::new);
+
+        if (member.getAccounts().contains(account)) {
+            Stock stock = stockRepository.findByCode(dto.stockCode())
+                    .orElseThrow(NoSuchElementException::new);
+            long needMoney = stock.getPrice() * dto.quantity();
+
+            if (account.getMoney() >= needMoney) {
+                Trade trade = Trade.builder()
+                        .account(account)
+                        .stock(stock)
+                        .quantity(dto.quantity())
+                        .build();
+
+                account.buy(needMoney);
+                account.getTrades().add(trade);
+                tradeRepository.save(trade);
+                return true;
+            } else {
+                throw new IllegalArgumentException("not enough money");
+            }
+        } else {
+            throw new AuthenticationException();
+        }
+    }
+
+    public boolean sell(String memberEmail, TradeRequestDto dto) throws AuthenticationException {
+        Member member = memberRepository.getMemberByEmail(memberEmail);
+        Account account = accountRepository.findById(dto.accountId())
+                .orElseThrow(NoSuchElementException::new);
+
+        if (member.getAccounts().contains(account)) {
+            List<Trade> trades = account.getTrades().stream()
+                    .filter(trade -> trade.getStock().getCode().equals(dto.stockCode()))
+                    .sorted(Comparator.comparingInt(Trade::getQuantity).reversed())
+                    .toList();
+
+            int remainingQuantity = dto.quantity();
+
+            for (Trade trade : trades) {
+                if (remainingQuantity <= 0) {
+                    break;
+                }
+
+                int tradeQuantity = trade.getQuantity();
+                if (tradeQuantity >= remainingQuantity) {
+                    trade.sell(remainingQuantity);
+                    remainingQuantity = 0;
+                } else {
+                    tradeRepository.delete(trade);
+                    remainingQuantity -= tradeQuantity;
+                }
+            }
+            return true;
+        } else {
+            throw new AuthenticationException();
+        }
+    }
+}

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
@@ -5,7 +5,7 @@ import com.example.stocksimulation.domain.entity.Member;
 import com.example.stocksimulation.domain.entity.Stock;
 import com.example.stocksimulation.domain.entity.Trade;
 import com.example.stocksimulation.domain.vo.TradeType;
-import com.example.stocksimulation.domain.vo.TradeVO;
+import com.example.stocksimulation.domain.vo.ZeroTradeQuantity;
 import com.example.stocksimulation.dto.trade.TradeRequestDto;
 import com.example.stocksimulation.repository.MemberRepository;
 import com.example.stocksimulation.repository.StockRepository;
@@ -67,7 +67,7 @@ public class TradeService {
 
     @Async
     public void deleteCompletedTradesAsync() {
-        List<Trade> completedTrades = tradeRepository.findAllByQuantity(TradeVO.EMPTY_TRADE.getQuantity());
+        List<Trade> completedTrades = tradeRepository.findAllByQuantity(ZeroTradeQuantity.EMPTY_TRADE.getQuantity());
         tradeRepository.deleteAll(completedTrades);
     }
 }

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
@@ -21,6 +21,7 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 @Service
 public class TradeService {
+    private final TradeTraceService traceService;
     private final TradeRepository tradeRepository;
     private final MemberRepository memberRepository;
     private final StockRepository stockRepository;
@@ -43,7 +44,6 @@ public class TradeService {
                     .build();
 
                 account.buy(trade);
-                tradeRepository.save(trade);
                 break;
             case SELL :
                 trade = Trade.builder()
@@ -55,9 +55,12 @@ public class TradeService {
 
                 account.sell(trade);
                 deleteCompletedTradesAsync();
-                tradeRepository.save(trade);
                 break;
+            default:
+                throw new IllegalArgumentException("not available trade type");
         }
+        tradeRepository.save(trade);
+        traceService.recordTrace(trade);
 
         return true;
     }

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeService.java
@@ -5,14 +5,17 @@ import com.example.stocksimulation.domain.entity.Member;
 import com.example.stocksimulation.domain.entity.Stock;
 import com.example.stocksimulation.domain.entity.Trade;
 import com.example.stocksimulation.domain.vo.TradeType;
+import com.example.stocksimulation.domain.vo.TradeVO;
 import com.example.stocksimulation.dto.trade.TradeRequestDto;
 import com.example.stocksimulation.repository.MemberRepository;
 import com.example.stocksimulation.repository.StockRepository;
 import com.example.stocksimulation.repository.TradeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
@@ -51,10 +54,17 @@ public class TradeService {
                         .build();
 
                 account.sell(trade);
+                deleteCompletedTradesAsync();
                 tradeRepository.save(trade);
                 break;
         }
 
         return true;
+    }
+
+    @Async
+    public void deleteCompletedTradesAsync() {
+        List<Trade> completedTrades = tradeRepository.findAllByQuantity(TradeVO.EMPTY_TRADE.getQuantity());
+        tradeRepository.deleteAll(completedTrades);
     }
 }

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeTraceService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeTraceService.java
@@ -1,0 +1,21 @@
+package com.example.stocksimulation.service.stock;
+
+import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.domain.entity.TradeTrace;
+import com.example.stocksimulation.repository.TradeTraceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TradeTraceService {
+    private final TradeTraceRepository repository;
+
+    public void recordTrace(Trade trade) {
+        TradeTrace trace = TradeTrace.builder()
+                .trade(trade)
+                .build();
+
+        repository.save(trace);
+    }
+}

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeTraceService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeTraceService.java
@@ -1,15 +1,34 @@
 package com.example.stocksimulation.service.stock;
 
+import com.example.stocksimulation.domain.entity.Member;
 import com.example.stocksimulation.domain.entity.Trade;
 import com.example.stocksimulation.domain.entity.TradeTrace;
+import com.example.stocksimulation.dto.trade.TradeTraceDto;
+import com.example.stocksimulation.repository.MemberRepository;
 import com.example.stocksimulation.repository.TradeTraceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class TradeTraceService {
     private final TradeTraceRepository repository;
+    private final MemberRepository memberRepository;
+
+    public List<TradeTraceDto> readAll(String memberEmail) {
+        Member member = memberRepository.getMemberByEmail(memberEmail);
+        List<TradeTrace> traces = member.getAccount().getTraces();
+        List<TradeTraceDto> response = new ArrayList<>();
+
+        for (TradeTrace trace : traces) {
+            response.add(trace.toDto());
+        }
+
+        return response;
+    }
 
     public void recordTrace(Trade trade) {
         TradeTrace trace = TradeTrace.builder()

--- a/src/main/java/com/example/stocksimulation/service/stock/TradeTraceService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TradeTraceService.java
@@ -24,7 +24,7 @@ public class TradeTraceService {
         List<TradeTraceDto> response = new ArrayList<>();
 
         for (TradeTrace trace : traces) {
-            response.add(trace.toDto());
+            response.add(TradeTraceDto.create(trace));
         }
 
         return response;

--- a/src/main/java/com/example/stocksimulation/service/stock/Trader.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/Trader.java
@@ -1,0 +1,17 @@
+package com.example.stocksimulation.service.stock;
+
+import com.example.stocksimulation.domain.entity.Account;
+import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.repository.TradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public abstract class Trader {
+    final TradeRepository tradeRepository;
+
+    @Transactional
+    public abstract void trade(Account account, Trade trade);
+}

--- a/src/main/java/com/example/stocksimulation/service/stock/TraderConstructor.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/TraderConstructor.java
@@ -1,0 +1,21 @@
+package com.example.stocksimulation.service.stock;
+
+import com.example.stocksimulation.domain.entity.*;
+import com.example.stocksimulation.repository.TradeRepository;
+
+public enum TraderConstructor {
+    BUY {
+        @Override
+        public Trader createTrader(TradeRepository tradeRepository) {
+            return new BuyTrader(tradeRepository);
+        }
+    },
+    SELL {
+        @Override
+        public Trader createTrader(TradeRepository tradeRepository) {
+            return new SellTrader(tradeRepository);
+        }
+    };
+
+    public abstract Trader createTrader(TradeRepository tradeRepository);
+}

--- a/src/main/java/com/example/stocksimulation/service/stock/WebSocketConnectService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/WebSocketConnectService.java
@@ -1,6 +1,6 @@
 package com.example.stocksimulation.service.stock;
 
-import com.example.stocksimulation.domain.vo.WebSocketClientVO;
+import com.example.stocksimulation.domain.vo.WebSocketParsingInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -16,7 +16,7 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 @Service
 public class WebSocketConnectService {
-    private final String socketUrl = WebSocketClientVO.WEB_SOCKET_CLIENT_URL.getValue();
+    private final String socketUrl = WebSocketParsingInfo.WEB_SOCKET_CLIENT_URL.getValue();
     private final WebSocketHandler handler;
     private WebSocketSession session;
 

--- a/src/main/java/com/example/stocksimulation/service/stock/WebSocketConnectService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/WebSocketConnectService.java
@@ -1,8 +1,9 @@
 package com.example.stocksimulation.service.stock;
 
 import com.example.stocksimulation.domain.vo.WebSocketClientVO;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketHandler;
@@ -13,12 +14,16 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 @Slf4j
-@RequiredArgsConstructor
 @Service
 public class WebSocketConnectService {
     private final String socketUrl = WebSocketClientVO.WEB_SOCKET_CLIENT_URL.getValue();
     private final WebSocketHandler handler;
     private WebSocketSession session;
+
+    @Autowired
+    public WebSocketConnectService(@Qualifier("serverToApiHandler")WebSocketHandler handler) {
+        this.handler = handler;
+    }
 
     public void connect() {
         try {

--- a/src/main/java/com/example/stocksimulation/service/support/MemberEmailAspect.java
+++ b/src/main/java/com/example/stocksimulation/service/support/MemberEmailAspect.java
@@ -1,0 +1,20 @@
+package com.example.stocksimulation.service.support;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+public class MemberEmailAspect {
+    @Before("execution(* com.example.stocksimulation.web.controller.*.*(..))")
+    public void beforeControllerMethodExecution() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String memberEmail = request.getUserPrincipal().getName();
+        request.setAttribute("memberId", memberEmail);
+    }
+}

--- a/src/main/java/com/example/stocksimulation/service/support/MemberEmailAspect.java
+++ b/src/main/java/com/example/stocksimulation/service/support/MemberEmailAspect.java
@@ -1,6 +1,7 @@
 package com.example.stocksimulation.service.support;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
@@ -9,12 +10,15 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class MemberEmailAspect {
+    private final HttpServletRequest request;
     @Before("execution(* com.example.stocksimulation.web.controller.*.*(..))")
-    public void beforeControllerMethodExecution() {
+    public void setMemberEmail() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
         String memberEmail = request.getUserPrincipal().getName();
-        request.setAttribute("memberId", memberEmail);
+        System.out.println(memberEmail);
+        request.setAttribute("memberEmail", memberEmail);
     }
 }

--- a/src/main/java/com/example/stocksimulation/service/support/WebSocketClientToServerHandler.java
+++ b/src/main/java/com/example/stocksimulation/service/support/WebSocketClientToServerHandler.java
@@ -1,0 +1,72 @@
+package com.example.stocksimulation.service.support;
+
+import com.example.stocksimulation.dto.stock.StockDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Getter
+@Component("clientToServerHandler")
+@RequiredArgsConstructor
+public class WebSocketClientToServerHandler extends TextWebSocketHandler {
+    private static final ConcurrentHashMap<String, WebSocketSession> CLIENTS = new ConcurrentHashMap<>();
+    public final Map<String, StockDto> stocks = new HashMap<>();
+    private final ObjectMapper objectMapper;
+
+    public void sendStockDtoToAllClients(StockDto stockDto) {
+        String stockDtoJson;
+        try {
+            stockDtoJson = objectMapper.writeValueAsString(stockDto);
+        } catch (IOException e) {
+            log.warn("WebSocketServer : change stock info to json error", e);
+            return;
+        }
+
+        TextMessage updateInfo = new TextMessage(stockDtoJson);
+
+        CLIENTS.forEach((id, session) -> {
+            try {
+                session.sendMessage(updateInfo);
+            } catch (IOException e) {
+                log.warn("WebSocketServer : send update info error", e);
+            }
+        });
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        String stocksDtoJson;
+        try {
+            stocksDtoJson = objectMapper.writeValueAsString(stocks);
+        } catch (IOException e) {
+            log.warn("WebSocketServer : change stocks list to json error", e);
+            return;
+        }
+
+        TextMessage stocksInfo = new TextMessage(stocksDtoJson);
+
+        CLIENTS.put(session.getId(), session);
+        try {
+            session.sendMessage(stocksInfo);
+        } catch (IOException e) {
+            log.warn("WebSocketServer : send stocks info error", e);
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        CLIENTS.remove(session.getId());
+    }
+}

--- a/src/main/java/com/example/stocksimulation/service/support/WebSocketServerToApiHandler.java
+++ b/src/main/java/com/example/stocksimulation/service/support/WebSocketServerToApiHandler.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 
 @RequiredArgsConstructor
 @Slf4j
-@Component
-public class WebSocketClientSessionHandler extends TextWebSocketHandler {
+@Component("serverToApiHandler")
+public class WebSocketServerToApiHandler extends TextWebSocketHandler {
     private final StockService service;
     private final TaskScheduler taskScheduler = new SimpleAsyncTaskScheduler();
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -38,7 +38,7 @@ public class WebSocketClientSessionHandler extends TextWebSocketHandler {
             String code = response[WebSocketClientNumberVO.INDEX_OF_CODE.getValue()];
             String price = response[WebSocketClientNumberVO.INDEX_OF_PRICE.getValue()];
 
-            service.updateStockPrice(code, price);
+            service.updateStockPrice(code, Integer.parseInt(price));
         } else if (message.getPayload().contains("SUBSCRIBE SUCCESS")) {
             connectedVO = objectMapper.readValue(message.getPayload(), WebSocketConnectedVO.class);
             JsonNode jsonNode = objectMapper.readTree(message.getPayload());

--- a/src/main/java/com/example/stocksimulation/service/support/WebSocketServerToApiHandler.java
+++ b/src/main/java/com/example/stocksimulation/service/support/WebSocketServerToApiHandler.java
@@ -1,8 +1,8 @@
 package com.example.stocksimulation.service.support;
 
-import com.example.stocksimulation.domain.vo.WebSocketClientNumberVO;
-import com.example.stocksimulation.domain.vo.WebSocketClientVO;
-import com.example.stocksimulation.domain.vo.WebSocketConnectedVO;
+import com.example.stocksimulation.domain.vo.WebSocketIndexNumber;
+import com.example.stocksimulation.domain.vo.WebSocketParsingInfo;
+import com.example.stocksimulation.domain.vo.WebSocketConnectInfo;
 import com.example.stocksimulation.service.stock.StockService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -26,26 +26,26 @@ public class WebSocketServerToApiHandler extends TextWebSocketHandler {
     private final StockService service;
     private final TaskScheduler taskScheduler = new SimpleAsyncTaskScheduler();
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private WebSocketConnectedVO connectedVO;
+    private WebSocketConnectInfo connectedVO;
     private WebSocketSession session;
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws JsonProcessingException {
         log.info("webSocketClient : Received message from server");
         if (message.getPayload().startsWith("0") || message.getPayload().startsWith("1")) {
-            String[] responses = message.getPayload().split(WebSocketClientVO.WEB_SOCKET_CLIENT_RESPONSE_SPLITER.getValue());
-            String[] response = responses[WebSocketClientNumberVO.INDEX_OF_RESPONSE.getValue()].split(WebSocketClientVO.WEB_SOCKET_CLIENT_PRICE_SPLITER.getValue());
-            String code = response[WebSocketClientNumberVO.INDEX_OF_CODE.getValue()];
-            String price = response[WebSocketClientNumberVO.INDEX_OF_PRICE.getValue()];
+            String[] responses = message.getPayload().split(WebSocketParsingInfo.WEB_SOCKET_CLIENT_RESPONSE_SPLITER.getValue());
+            String[] response = responses[WebSocketIndexNumber.INDEX_OF_RESPONSE.getValue()].split(WebSocketParsingInfo.WEB_SOCKET_CLIENT_PRICE_SPLITER.getValue());
+            String code = response[WebSocketIndexNumber.INDEX_OF_CODE.getValue()];
+            String price = response[WebSocketIndexNumber.INDEX_OF_PRICE.getValue()];
 
             service.updateStockPrice(code, Integer.parseInt(price));
         } else if (message.getPayload().contains("SUBSCRIBE SUCCESS")) {
-            connectedVO = objectMapper.readValue(message.getPayload(), WebSocketConnectedVO.class);
+            connectedVO = objectMapper.readValue(message.getPayload(), WebSocketConnectInfo.class);
             JsonNode jsonNode = objectMapper.readTree(message.getPayload());
             String msg1 = jsonNode.path("body").path("msg1").asText();
             String iv = jsonNode.path("body").path("output").path("iv").asText();
             String key = jsonNode.path("body").path("output").path("key").asText();
-            connectedVO = new WebSocketConnectedVO(msg1, iv, key);
+            connectedVO = new WebSocketConnectInfo(msg1, iv, key);
             System.out.println("Message: " + message.getPayload());
         }
     }
@@ -71,7 +71,7 @@ public class WebSocketServerToApiHandler extends TextWebSocketHandler {
 
     private void sendHeartbeat() {
         try {
-            session.sendMessage(new TextMessage(WebSocketClientVO.WEB_SOCKET_CLIENT_HEARTBEAT.getValue()));
+            session.sendMessage(new TextMessage(WebSocketParsingInfo.WEB_SOCKET_CLIENT_HEARTBEAT.getValue()));
         } catch (IOException e){
             log.warn("webSocketClient : WebSocket session is not open.");
             log.warn("Exception : ", e);

--- a/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
@@ -32,4 +32,13 @@ public class AccountController {
         AccountInfoDto response = service.readAccount(memberEmail);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/balance")
+    public ResponseEntity<Long> getBalance() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberEmail = authentication.getName();
+
+        long response = service.getBalance(memberEmail);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
@@ -1,32 +1,26 @@
 package com.example.stocksimulation.web.controller.account;
 
-import com.example.stocksimulation.domain.entity.Account;
-import com.example.stocksimulation.domain.entity.Member;
-import com.example.stocksimulation.repository.AccountRepository;
-import com.example.stocksimulation.repository.MemberRepository;
+import com.example.stocksimulation.dto.account.AccountInfoDto;
+import com.example.stocksimulation.service.account.AccountService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
 @RestController
 public class AccountController {
-    private final AccountRepository repository;
-    private final MemberRepository memberRepository;
+    private final AccountService service;
 
     @PostMapping("/account")
-    public void makeAccount() {
+    public ResponseEntity<AccountInfoDto> makeAccount() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String memberId = authentication.getName();
-        Member m = memberRepository.findByEmail(memberId)
-                .orElseThrow(NoSuchElementException::new);
+        String memberEmail = authentication.getName();
 
-        Account account = new Account(m);
-        m.setAccount(account);
-        repository.save(account);
+        AccountInfoDto response = service.create(memberEmail);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
@@ -23,4 +23,13 @@ public class AccountController {
         AccountInfoDto response = service.create(memberEmail);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/account")
+    public ResponseEntity<AccountInfoDto> read() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberEmail = authentication.getName();
+
+        AccountInfoDto response = service.readAccount(memberEmail);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/account/AccountController.java
@@ -1,0 +1,32 @@
+package com.example.stocksimulation.web.controller.account;
+
+import com.example.stocksimulation.domain.entity.Account;
+import com.example.stocksimulation.domain.entity.Member;
+import com.example.stocksimulation.repository.AccountRepository;
+import com.example.stocksimulation.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@RestController
+public class AccountController {
+    private final AccountRepository repository;
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/account")
+    public void makeAccount() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberId = authentication.getName();
+        Member m = memberRepository.findByEmail(memberId)
+                .orElseThrow(NoSuchElementException::new);
+
+        Account account = new Account(m);
+        m.setAccount(account);
+        repository.save(account);
+    }
+}

--- a/src/main/java/com/example/stocksimulation/web/controller/membership/MemberController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/membership/MemberController.java
@@ -57,7 +57,10 @@ public class MemberController {
     public ResponseEntity<MemberUpdateDto> update(
             @Parameter(description = "수정 요소들", required = true)
             @RequestBody MemberUpdateDto updateDto) {
-        MemberUpdateDto response = service.update(updateDto);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberEmail = authentication.getName();
+
+        MemberUpdateDto response = service.update(updateDto, memberEmail);
         return ResponseEntity.ok(response);
     }
 
@@ -66,24 +69,11 @@ public class MemberController {
     @ApiResponse(responseCode = "400", description = "잘못된 요청 형식입니다")
     @ApiResponse(responseCode = "500", description = "내부 서버 오류 발생")
     @DeleteMapping("/member")
-    public ResponseEntity<Long> delete(
-            @Parameter(description = "삭제할 Member Id", required = true)
-            @RequestParam Long memberId) {
-        long response = service.delete(memberId);
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/your-endpoint")
-    public String yourMethod() {
-        // 현재 사용자의 인증 객체를 가져옴
+    public ResponseEntity<String> delete() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberEmail = authentication.getName();
 
-        // 사용자의 이름을 가져옴
-        String memberId = authentication.getName();
-
-        // memberId를 사용하여 원하는 작업 수행
-        // 예를 들어, memberId로 회원 정보를 가져오거나 다른 작업을 수행할 수 있음
-
-        return "Member ID: " + memberId;
+        String response = service.delete(memberEmail);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/membership/MemberController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/membership/MemberController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,7 +45,6 @@ public class MemberController {
     public ResponseEntity<JwtToken> signIn(
             @Parameter(description = "로그인 요청 정보", required = true)
             @RequestBody @Validated MemberSignInDto signInDto) {
-        System.out.println("controller");
         JwtToken token = service.signIn(signInDto.email(), signInDto.password());
         return ResponseEntity.ok(token);
     }
@@ -70,5 +71,19 @@ public class MemberController {
             @RequestParam Long memberId) {
         long response = service.delete(memberId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/your-endpoint")
+    public String yourMethod() {
+        // 현재 사용자의 인증 객체를 가져옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 사용자의 이름을 가져옴
+        String memberId = authentication.getName();
+
+        // memberId를 사용하여 원하는 작업 수행
+        // 예를 들어, memberId로 회원 정보를 가져오거나 다른 작업을 수행할 수 있음
+
+        return "Member ID: " + memberId;
     }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/StockClientController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/StockClientController.java
@@ -1,0 +1,22 @@
+package com.example.stocksimulation.web.controller.stock;
+
+import com.example.stocksimulation.dto.stock.StockDto;
+import com.example.stocksimulation.service.stock.StockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class StockClientController {
+    private final StockService service;
+
+    @GetMapping("/stocks-info")
+    public ResponseEntity<List<StockDto>> getStocksInfo() {
+        List<StockDto> response = service.readAll();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/StockClientController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/StockClientController.java
@@ -13,10 +13,10 @@ import java.util.List;
 @RestController
 public class StockClientController {
     private final StockService service;
-
+/*
     @GetMapping("/stocks-info")
     public ResponseEntity<List<StockDto>> getStocksInfo() {
         List<StockDto> response = service.readAll();
         return ResponseEntity.ok(response);
-    }
+    }*/
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/StockController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/StockController.java
@@ -1,15 +1,18 @@
 package com.example.stocksimulation.web.controller.stock;
 
 import com.example.stocksimulation.domain.vo.WebSocketClientVO;
+import com.example.stocksimulation.service.stock.StockService;
 import com.example.stocksimulation.service.stock.WebSocketConnectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class StockController {
     private final WebSocketConnectService service;
+    private final StockService stockService;
 
     @GetMapping("/stocks")
     public void stocks() {
@@ -20,5 +23,11 @@ public class StockController {
     public void send() {
         String request = WebSocketClientVO.WEB_SOCKET_CLIENT_REQUEST.getValue();
         service.send(request);
+    }
+
+    @PostMapping("/stock")
+    public String save() {
+        stockService.saveTest();
+        return "save";
     }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/StockController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/StockController.java
@@ -1,6 +1,6 @@
 package com.example.stocksimulation.web.controller.stock;
 
-import com.example.stocksimulation.domain.vo.WebSocketClientVO;
+import com.example.stocksimulation.domain.vo.WebSocketParsingInfo;
 import com.example.stocksimulation.service.stock.StockService;
 import com.example.stocksimulation.service.stock.WebSocketConnectService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class StockController {
 
     @GetMapping("/send")
     public void send() {
-        String request = WebSocketClientVO.WEB_SOCKET_CLIENT_REQUEST.getValue();
+        String request = WebSocketParsingInfo.WEB_SOCKET_CLIENT_REQUEST.getValue();
         service.send(request);
     }
 

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
@@ -1,0 +1,31 @@
+package com.example.stocksimulation.web.controller.stock;
+
+import com.example.stocksimulation.domain.vo.TradeType;
+import com.example.stocksimulation.dto.trade.TradeRequestDto;
+import com.example.stocksimulation.service.stock.TradeService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TradeController {
+    private final TradeService service;
+
+    @PostMapping("/buy")
+    public ResponseEntity<Boolean> buy(@RequestBody TradeRequestDto dto,
+                                       HttpServletRequest request) {
+        boolean response = service.trade((String) request.getAttribute("memberId"), dto, TradeType.BUY);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/sell")
+    public ResponseEntity<Boolean> sell(@RequestBody TradeRequestDto dto,
+                                       HttpServletRequest request) {
+        boolean response = service.trade((String) request.getAttribute("memberId"), dto, TradeType.SELL);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
@@ -3,9 +3,10 @@ package com.example.stocksimulation.web.controller.stock;
 import com.example.stocksimulation.domain.vo.TradeType;
 import com.example.stocksimulation.dto.trade.TradeRequestDto;
 import com.example.stocksimulation.service.stock.TradeService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,16 +17,22 @@ public class TradeController {
     private final TradeService service;
 
     @PostMapping("/buy")
-    public ResponseEntity<Boolean> buy(@RequestBody TradeRequestDto dto,
-                                       HttpServletRequest request) {
-        boolean response = service.trade((String) request.getAttribute("memberId"), dto, TradeType.BUY);
+    public ResponseEntity<Boolean> buy(@RequestBody TradeRequestDto dto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 사용자의 이름을 가져옴
+        String memberId = authentication.getName();
+        boolean response = service.trade(memberId, dto, TradeType.BUY);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/sell")
-    public ResponseEntity<Boolean> sell(@RequestBody TradeRequestDto dto,
-                                       HttpServletRequest request) {
-        boolean response = service.trade((String) request.getAttribute("memberId"), dto, TradeType.SELL);
+    public ResponseEntity<Boolean> sell(@RequestBody TradeRequestDto dto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 사용자의 이름을 가져옴
+        String memberId = authentication.getName();
+        boolean response = service.trade(memberId, dto, TradeType.SELL);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
@@ -19,9 +19,8 @@ public class TradeController {
     @PostMapping("/buy")
     public ResponseEntity<Boolean> buy(@RequestBody TradeRequestDto dto) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        // 사용자의 이름을 가져옴
         String memberId = authentication.getName();
+
         boolean response = service.trade(memberId, dto, TradeType.BUY);
         return ResponseEntity.ok(response);
     }
@@ -29,9 +28,8 @@ public class TradeController {
     @PostMapping("/sell")
     public ResponseEntity<Boolean> sell(@RequestBody TradeRequestDto dto) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+       String memberId = authentication.getName();
 
-        // 사용자의 이름을 가져옴
-        String memberId = authentication.getName();
         boolean response = service.trade(memberId, dto, TradeType.SELL);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
@@ -19,18 +19,18 @@ public class TradeController {
     @PostMapping("/buy")
     public ResponseEntity<Boolean> buy(@RequestBody TradeRequestDto dto) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String memberId = authentication.getName();
+        String memberEmail = authentication.getName();
 
-        boolean response = service.trade(memberId, dto, TradeType.BUY);
+        boolean response = service.trade(memberEmail, dto, TradeType.BUY);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/sell")
     public ResponseEntity<Boolean> sell(@RequestBody TradeRequestDto dto) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-       String memberId = authentication.getName();
+       String memberEmail = authentication.getName();
 
-        boolean response = service.trade(memberId, dto, TradeType.SELL);
+        boolean response = service.trade(memberEmail, dto, TradeType.SELL);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/TradeController.java
@@ -3,6 +3,7 @@ package com.example.stocksimulation.web.controller.stock;
 import com.example.stocksimulation.domain.vo.TradeType;
 import com.example.stocksimulation.dto.trade.TradeRequestDto;
 import com.example.stocksimulation.service.stock.TradeService;
+import com.example.stocksimulation.service.stock.TraderConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -21,7 +22,7 @@ public class TradeController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String memberEmail = authentication.getName();
 
-        boolean response = service.trade(memberEmail, dto, TradeType.BUY);
+        boolean response = service.trade(memberEmail, dto, TraderConstructor.BUY, TradeType.BUY);
         return ResponseEntity.ok(response);
     }
 
@@ -30,7 +31,7 @@ public class TradeController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
        String memberEmail = authentication.getName();
 
-        boolean response = service.trade(memberEmail, dto, TradeType.SELL);
+        boolean response = service.trade(memberEmail, dto, TraderConstructor.SELL, TradeType.SELL);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/stocksimulation/web/controller/stock/TradeTraceController.java
+++ b/src/main/java/com/example/stocksimulation/web/controller/stock/TradeTraceController.java
@@ -1,0 +1,27 @@
+package com.example.stocksimulation.web.controller.stock;
+
+import com.example.stocksimulation.dto.trade.TradeTraceDto;
+import com.example.stocksimulation.service.stock.TradeTraceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class TradeTraceController {
+    private final TradeTraceService service;
+
+    @GetMapping("/trade-trace")
+    public ResponseEntity<List<TradeTraceDto>> readAllTrace() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String memberEmail = authentication.getName();
+
+        List<TradeTraceDto> response = service.readAll(memberEmail);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ jwt.secret=64461f01e1af406da538b9c48d801ce59142452199ff112fb5404c8e7e98e3ff
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/stock-simul?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&rewriteBatchedStatements=true&serverTimezone=Asia/Seoul
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.datasource.username=admin
+spring.datasource.username=root
 spring.datasource.password=kakao4851?
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,16 @@ spring.application.name=stock-simulation
 
 #jwt
 jwt.secret=64461f01e1af406da538b9c48d801ce59142452199ff112fb5404c8e7e98e3ff
+
+#mysql
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/stock-simul?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&rewriteBatchedStatements=true&serverTimezone=Asia/Seoul
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.datasource.username=admin
+spring.datasource.password=kakao4851?
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.jdbc.batch_size=100
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true

--- a/src/test/java/com/example/stocksimulation/domain/entity/AccountTest.java
+++ b/src/test/java/com/example/stocksimulation/domain/entity/AccountTest.java
@@ -1,0 +1,60 @@
+package com.example.stocksimulation.domain.entity;
+
+import com.example.stocksimulation.domain.vo.TradeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AccountTest {
+    private Account account;
+    private Stock stock;
+
+    @BeforeEach
+    void setUp() {
+        account = new Account();
+        stock = new Stock("TEST_CODE", 5000, "test");
+    }
+
+    @Test
+    void 매수_성공_테스트() {
+        int testQuantity = 10;
+        long testPrice = 5000;
+        Trade trade = new Trade(account, stock, testQuantity, TradeType.BUY);
+
+        account.buy(trade);
+
+        assertEquals(500000 - testPrice * testQuantity, account.getMoney());
+        assertEquals(1, account.getTrades().size());
+    }
+
+    @Test
+    void 매도_성공_테스트() {
+        int buyQuantity = 10;
+        int sellQuantity = 5;
+        long testPrice = 5000;
+
+        Trade buyTrade = new Trade(account, stock, buyQuantity, TradeType.BUY);
+        account.buy(buyTrade);
+
+        Trade sellTrade = new Trade(account, stock, sellQuantity, TradeType.SELL);
+        account.sell(sellTrade);
+
+        assertEquals(500000 - testPrice * buyQuantity + testPrice * sellQuantity, account.getMoney());
+        assertEquals(buyQuantity - sellQuantity, account.getTrades().get(0).getQuantity());
+    }
+
+    @Test
+    void 매도_실패_테스트_불충분한_주식() {
+        int buyQuantity = 10;
+        int sellQuantity = 15;
+
+        Trade buyTrade = new Trade(account, stock, buyQuantity, TradeType.BUY);
+        account.buy(buyTrade);
+
+        Trade sellTrade = new Trade(account, stock, sellQuantity, TradeType.SELL);
+
+        assertThrows(IllegalArgumentException.class, () -> account.sell(sellTrade));
+    }
+}

--- a/src/test/java/com/example/stocksimulation/service/stock/TradeServiceTest.java
+++ b/src/test/java/com/example/stocksimulation/service/stock/TradeServiceTest.java
@@ -1,0 +1,100 @@
+package com.example.stocksimulation.service.stock;
+
+import com.example.stocksimulation.domain.entity.Account;
+import com.example.stocksimulation.domain.entity.Member;
+import com.example.stocksimulation.domain.entity.Stock;
+import com.example.stocksimulation.domain.entity.Trade;
+import com.example.stocksimulation.domain.vo.TradeType;
+import com.example.stocksimulation.dto.trade.TradeRequestDto;
+import com.example.stocksimulation.repository.MemberRepository;
+import com.example.stocksimulation.repository.StockRepository;
+import com.example.stocksimulation.repository.TradeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TradeServiceTest {
+
+    @Mock
+    private TradeTraceService traceService;
+
+    @Mock
+    private TradeRepository tradeRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @InjectMocks
+    private TradeService tradeService;
+
+    private Member member;
+    private Account account;
+    private Stock stock;
+
+    @BeforeEach
+    void setUp() {
+        member = mock(Member.class);
+        account = new Account(member);
+        stock = new Stock("TEST_CODE", 5000, "test");
+
+        when(member.getAccount()).thenReturn(account);
+    }
+
+    @Test
+    void 매수_성공_테스트() {
+        TradeRequestDto dto = new TradeRequestDto("TEST_CODE", 10);
+        when(memberRepository.getMemberByEmail(anyString())).thenReturn(member);
+        when(stockRepository.findByCode(anyString())).thenReturn(Optional.of(stock));
+
+        boolean result = tradeService.trade("test@test.com", dto, TradeType.BUY);
+
+        ArgumentCaptor<Trade> tradeCaptor = ArgumentCaptor.forClass(Trade.class);
+        verify(tradeRepository).save(tradeCaptor.capture());
+        Trade savedTrade = tradeCaptor.getValue();
+
+        assertEquals(true, result);
+        assertEquals(TradeType.BUY, savedTrade.getTradeType());
+        assertEquals(10, savedTrade.getQuantity());
+        assertEquals(stock, savedTrade.getStock());
+        assertEquals(account, savedTrade.getAccount());
+        verify(traceService).recordTrace(any(Trade.class));
+    }
+
+    @Test
+    void 매도_성공_테스트() {
+        TradeRequestDto dto = new TradeRequestDto("TEST_CODE", 5);
+        when(memberRepository.getMemberByEmail(anyString())).thenReturn(member);
+        when(stockRepository.findByCode(anyString())).thenReturn(Optional.of(stock));
+
+        Trade buyTrade = new Trade(account, stock, 10, TradeType.BUY);
+        account.buy(buyTrade);
+
+        boolean result = tradeService.trade("test@test.com", dto, TradeType.SELL);
+
+        ArgumentCaptor<Trade> tradeCaptor = ArgumentCaptor.forClass(Trade.class);
+        verify(tradeRepository).save(tradeCaptor.capture());
+        Trade savedTrade = tradeCaptor.getValue();
+
+        assertEquals(true, result);
+        assertEquals(TradeType.BUY, savedTrade.getTradeType());
+        assertEquals(5, savedTrade.getQuantity());
+        assertEquals(stock, savedTrade.getStock());
+        assertEquals(account, savedTrade.getAccount());
+        verify(traceService).recordTrace(any(Trade.class));
+        verify(tradeRepository).deleteAll(anyList());
+    }
+}


### PR DESCRIPTION
## Issue
- 주식 entity에 대한 매수와 매도 기능을 구현함
- 주식의 거래 기록을 표시하기 위한 TradeTrace가 포함됨

</br>

## Class
### Account.java
- 주식에 대한 매도와 매수기능은 Account의 역할이라 판단했기에, Account entity에서 처리하도록 구현했습니다.
- Account는 기본적으로 Member와 1:1 매핑을 하도록 구현했습니다, 물론 한 회원이 여러 주식계좌를 가질 수 있지만, 현 프로젝트에서는 하나의 계좌만을 갖도록 구현했습니다.

### Trade
- 주식 매수, 매도에 관한 거래 entity입니다, 거래 유형과 거래한 주식의 수, 주식의 정보를 가지고 있으며, 매수와 매도가 Trade entity를 생성함으로써 기능이 작동하도록 구현했습니다.

### TradeTrace
- 매도와 매수 채결시, 자신의 주식 보유를 계산하고, 매도, 매수 관련 로직을 처리하기 위한 Trade entity와는 달리 거래를 기록하기 위한 entity로, Trade가 생성될 때 함께 생성됩니다.

### TestCode
- 의미있는 테스트 코드만을 작성하고자, 매도와 매수 기능에 집중하여 테스트 코드를 구현했습니다.
- 나머지는 테스트할 의미가 없다고 느껴 테스트 코드를 따로 작성하지 않았습니다.



**file changed가 왜이렇게 많은건지 모르겠네요.....ㅜㅜ , 아마 짜잘짜잘하게 수정한 설정 부분이 많은 비중을 차지한 것 같습니다.**