### PR TITLE
실시간 계좌 금액 업데이트 구현 PR

### DIFF
--- a/src/main/java/com/example/stocksimulation/configuration/WebSocketConfig.java
+++ b/src/main/java/com/example/stocksimulation/configuration/WebSocketConfig.java
@@ -11,15 +11,19 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @Configuration
 @EnableWebSocket
 public class WebSocketConfig implements WebSocketConfigurer {
-    private final WebSocketHandler webSocketHandler;
+    private final WebSocketHandler stockInfoHandler;
+    private final WebSocketHandler balanceHandler;
 
     @Autowired
-    public WebSocketConfig(@Qualifier("clientToServerHandler") WebSocketHandler webSocketHandler) {
-        this.webSocketHandler = webSocketHandler;
+    public WebSocketConfig(@Qualifier("clientToServerHandler") WebSocketHandler stockInfoHandler,
+                           @Qualifier("balanceWebSocketHandler") WebSocketHandler balanceHandler) {
+        this.stockInfoHandler = stockInfoHandler;
+        this.balanceHandler = balanceHandler;
     }
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/stocks-info").setAllowedOrigins("*");
+        registry.addHandler(stockInfoHandler, "/stocks-infos").setAllowedOrigins("*");
+        registry.addHandler(balanceHandler, "/balance").setAllowedOrigins("*");
     }
 }

--- a/src/main/java/com/example/stocksimulation/service/account/WebSocketForBalance.java
+++ b/src/main/java/com/example/stocksimulation/service/account/WebSocketForBalance.java
@@ -1,0 +1,42 @@
+package com.example.stocksimulation.service.account;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component("balanceWebSocketHandler")
+@RequiredArgsConstructor
+public class WebSocketForBalance extends TextWebSocketHandler {
+    private static final ConcurrentHashMap<String, WebSocketSession> CLIENTS = new ConcurrentHashMap<>();
+
+    public void sendMessageToAllClients() {
+        TextMessage textMessage = new TextMessage("update balance");
+
+        CLIENTS.forEach((id, session) -> {
+            try {
+                session.sendMessage(textMessage);
+            } catch (IOException e) {
+                log.warn("WebSocketServer : send message error", e);
+            }
+        });
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        CLIENTS.put(session.getId(), session);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        CLIENTS.remove(session.getId());
+    }
+}
+

--- a/src/main/java/com/example/stocksimulation/service/stock/StockService.java
+++ b/src/main/java/com/example/stocksimulation/service/stock/StockService.java
@@ -3,6 +3,7 @@ package com.example.stocksimulation.service.stock;
 import com.example.stocksimulation.domain.entity.Stock;
 import com.example.stocksimulation.dto.stock.StockDto;
 import com.example.stocksimulation.repository.StockRepository;
+import com.example.stocksimulation.service.account.WebSocketForBalance;
 import com.example.stocksimulation.service.support.WebSocketClientToServerHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 public class StockService {
     private final StockRepository repository;
     private final WebSocketClientToServerHandler socketServerHandler;
+    private final WebSocketForBalance socketForBalance;
 
     @Transactional
     public void updateStockPrice(String stockCode, int price) {
@@ -27,6 +29,7 @@ public class StockService {
             StockDto stockDto = stock.toDto();
             socketServerHandler.stocks.put(stockCode, stockDto);
             socketServerHandler.sendStockDtoToAllClients(stockDto);
+            socketForBalance.sendMessageToAllClients();
         }
     }
 


### PR DESCRIPTION
## Issue
- 계좌의 금액이 주식의 가격 변동에 따라 실시간으로 업데이트 되어야 합니다.
- 기존에 계획하던 방식인 주식 가격 업데이트 -> 변경된 주식이 포함된 Trade entity 조회 -> Trade를 소유한 Account 잔고 업데이트 방식에서 webSocket을 사용하여 자신의 Account정보를 조회하고 있는 회원에 한해서만 서버에서 업데이트 요청을 발생시키고 있습니다.

</br>
</br>

### 수정전

**주식 가격 업데이트 -> 변경된 주식이 포함된 Trade entity 조회 -> Trade를 소유한 Account 잔고 업데이트**

</br>

### 수정후

**주식 가격 업데이트 -> Account 정보를 조회중인 회원(WebSocket에 연결된 회원)에게만 변경되었음을 알리는 이벤트 발생 -> client의 Account 잔고 업데이트 api 호출**